### PR TITLE
fix(src): remove tags button grid on posts list and tags pages

### DIFF
--- a/app/posts/page/[id]/page.tsx
+++ b/app/posts/page/[id]/page.tsx
@@ -45,7 +45,8 @@ export default function Page({ params }: { params: { id: string } }) {
       <div className="mt-4 mb-8">
         <PaginationArrows totalPages={Math.ceil(postsLength / siteConfig.postNumPerPage)} currentId={id} href="/posts/page"/>
       </div>
-      <TagsButtonGrid/>
+      {/* Removing grid for the tags */}
+      {/* <TagsButtonGrid/> */}
     </DoublePane>
   )
 }

--- a/app/tags/[tag]/page/[id]/page.tsx
+++ b/app/tags/[tag]/page/[id]/page.tsx
@@ -31,10 +31,10 @@ export default function Page({ params }: { params: { tag: string, id: string } }
   const postsLength = getPostsLength({ tags: [tag] });
   
   if (
-    /^-?\d+$/.test(params.id) == false || 
+    /^-?\d+$/.test(params.id) === false || 
     startInd >= postsLength ||
     endInd <= 0 ||
-    getListOfAllTags().includes(tag) == false
+    getListOfAllTags().includes(tag) === false
   ) {
     notFound();
   }
@@ -48,7 +48,8 @@ export default function Page({ params }: { params: { tag: string, id: string } }
       <div className="mt-4 mb-8">
         <PaginationArrows totalPages={Math.ceil(postsLength / siteConfig.postNumPerPage)} currentId={id} href={`/tags/${tag}/page`}/>
       </div>
-      <TagsButtonGrid/>
+      {/* Removing the grid for the tags */}
+      {/* <TagsButtonGrid/> */}
     </DoublePane>
   )
 }

--- a/app/tags/page.tsx
+++ b/app/tags/page.tsx
@@ -21,8 +21,7 @@ export default function Page() {
       <h1 className="scroll-m-20 text-2xl font-semibold tracking-wide text-primary uppercase my-6">
         List of Tags on the Blog
       </h1>
-      <hr/>
-      <TagsButtonGrid/>
+      <TagsButtonGrid />
     </DoublePane>
   )
 }


### PR DESCRIPTION
The tags list was too long and it was disrupting the flow of the blog; thus, they were removed. Readers can also access tags pages by clicking them on posts to see more similar posts.

![image](https://github.com/user-attachments/assets/8ffe819a-bd1a-422c-8192-260917017735)
